### PR TITLE
Fix/error types

### DIFF
--- a/libdisplay-info/Cargo.toml
+++ b/libdisplay-info/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2021"
 [dependencies]
 libdisplay-info-sys = { version = "0.1.0", path = "../libdisplay-info-sys" }
 libc = "0.2.149"
+thiserror = "1.0.50"

--- a/libdisplay-info/src/cta.rs
+++ b/libdisplay-info/src/cta.rs
@@ -2,6 +2,7 @@ use std::marker::PhantomData;
 
 use crate::{edid::Extension, ffi};
 
+/// EDID CTA-861 extension block.
 #[derive(Debug)]
 pub struct CTA<'ext> {
     cta: *const ffi::cta::di_edid_cta,
@@ -32,6 +33,9 @@ impl<'ext> CTA<'ext> {
     }
 }
 
+/// Miscellaneous EDID CTA flags, defined in section 7.3.3.
+///
+/// For CTA revision 1, all of the fields are zero.
 #[derive(Debug)]
 pub struct Flags {
     pub it_underscan: bool,

--- a/libdisplay-info/src/edid.rs
+++ b/libdisplay-info/src/edid.rs
@@ -2,6 +2,7 @@ use std::marker::PhantomData;
 
 use crate::ffi;
 
+/// EDID data structure.
 #[derive(Debug)]
 pub struct Edid<'info> {
     edid: *const ffi::edid::di_edid,
@@ -29,6 +30,7 @@ impl<'info> Edid<'info> {
     }
 }
 
+/// EDID extension block tags, defined in section 2.2.4.
 #[derive(Debug, PartialEq, Eq)]
 #[repr(u32)]
 pub enum ExtensionTag {
@@ -64,6 +66,7 @@ impl From<u32> for ExtensionTag {
 pub struct Extension(*const ffi::edid::di_edid_ext);
 
 impl Extension {
+    /// Get the tag of an EDID extension block.
     pub fn tag(&self) -> ExtensionTag {
         unsafe { ffi::edid::di_edid_ext_get_tag(self.0) }.into()
     }

--- a/libdisplay-info/src/info.rs
+++ b/libdisplay-info/src/info.rs
@@ -1,5 +1,11 @@
 use crate::{edid::Edid, ffi, string_from_owned_ffi_ptr};
 
+/// Information about a display device.
+///
+/// This includes at least one EDID or DisplayID blob.
+///
+/// Use [`Info::parse`](Info::parse_edid) to create a [`Info`] from an EDID blob.
+/// DisplayID blobs are not yet supported.
 #[derive(Debug)]
 pub struct Info(*mut ffi::info::di_info);
 

--- a/libdisplay-info/src/info.rs
+++ b/libdisplay-info/src/info.rs
@@ -3,7 +3,9 @@ use crate::{edid::Edid, ffi, string_from_owned_ffi_ptr};
 #[derive(Debug)]
 pub struct Info(*mut ffi::info::di_info);
 
-#[derive(Debug)]
+/// Parsing the EDID blob failed
+#[derive(Debug, thiserror::Error)]
+#[error("Parsing the EDID blob failed")]
 pub struct ParseFailed;
 
 impl Info {


### PR DESCRIPTION
Impls error for the `ParseFailed` error and adds some missing docs

based on #1 