### PR TITLE
replace system-deps with just pkg-config

### DIFF
--- a/libdisplay-info-sys/Cargo.toml
+++ b/libdisplay-info-sys/Cargo.toml
@@ -24,13 +24,7 @@ v0_2 = []
 v0_3 = []
 
 [build-dependencies]
-system-deps = "7.0.3"
+pkg-config = "0.3.32"
 semver = "1.0.24"
 
 [dependencies]
-
-[package.metadata.system-deps.libdisplay-info]
-name = "libdisplay-info"
-version = ">= 0.1.0, < 0.4.0"
-v0_2 = { version = "0.2.0" }
-v0_3 = { version = "0.3.0" }

--- a/libdisplay-info-sys/build.rs
+++ b/libdisplay-info-sys/build.rs
@@ -1,18 +1,18 @@
-use system_deps::Dependencies;
-
 fn main() {
     if std::env::var("DOCS_RS").is_ok() {
         // don't link against unavailable native lib in doc.rs builds
         return;
     }
 
-    let deps = system_deps::Config::new().probe().unwrap();
-    auto_detect(&deps);
+    auto_detect();
 }
 
 #[cfg(feature = "auto")]
-fn auto_detect(deps: &Dependencies) {
-    let native_lib = deps.get_by_name("libdisplay-info").unwrap();
+fn auto_detect() {
+    let native_lib = pkg_config::Config::new()
+        .range_version("0.1.0".."0.4.0")
+        .probe("libdisplay-info")
+        .unwrap();
     let native_version = semver::Version::parse(&native_lib.version).unwrap();
     let is_v3 = semver::VersionReq::parse(">=0.3")
         .unwrap()
@@ -34,4 +34,4 @@ fn auto_detect(deps: &Dependencies) {
 }
 
 #[cfg(not(feature = "auto"))]
-fn auto_detect(_: &Dependencies) {}
+fn auto_detect() {}


### PR DESCRIPTION
the system-deps dependency was way overkill for finding the version of a single dependency and was unnecessarily pulling in the entirety of toml-edit, while still essentially only using pkg-config under the hood.